### PR TITLE
fix: Respect numeric-precision-and-scale and string-length options in node settings

### DIFF
--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -884,8 +884,11 @@ def get_columns(
 
     result_node: ResultNode | None = None
     if not isinstance(relation, BaseRelation):
-        if isinstance(relation, ResultNode):
-            result_node = relation
+        # NOTE: Technically, we should use `isinstance(relation, ResultNode)` to verify it’s a ResultNode,
+        #       but since ResultNode is defined as a Union[...], Python 3.9 raises
+        #       > TypeError: Subscripted generics cannot be used with class and instance checks
+        #       To avoid that, we’re skipping the isinstance check.
+        result_node = relation  # may be a ResultNode
         relation = context.project.adapter.Relation.create_from(
             context.project.adapter.config,  # pyright: ignore[reportUnknownArgumentType]
             relation,  # pyright: ignore[reportArgumentType]

--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -882,7 +882,10 @@ def get_columns(
         logger.debug(":blue_book: Relation is empty, skipping column collection.")
         return normalized_columns
 
+    result_node: ResultNode | None = None
     if not isinstance(relation, BaseRelation):
+        if isinstance(relation, ResultNode):
+            result_node = relation
         relation = context.project.adapter.Relation.create_from(
             context.project.adapter.config,  # pyright: ignore[reportUnknownArgumentType]
             relation,  # pyright: ignore[reportArgumentType]
@@ -913,7 +916,7 @@ def get_columns(
                 column.name, context.project.runtime_cfg.credentials.type
             )
             if not isinstance(column, ColumnMetadata):
-                dtype = _maybe_use_precise_dtype(column, context.settings)
+                dtype = _maybe_use_precise_dtype(column, context.settings, result_node)
                 column = ColumnMetadata(
                     name=normalized,
                     type=dtype,


### PR DESCRIPTION
- This PR is the same as https://github.com/z3z1ma/dbt-osmosis/pull/247
- The branch `patches` is used to run dbt-osmosis with the patched code until the Pull Request is merged.